### PR TITLE
Feature/relate messages to contests

### DIFF
--- a/app/Judge/Controllers/MessageController.php
+++ b/app/Judge/Controllers/MessageController.php
@@ -31,7 +31,7 @@ class MessageController extends BaseController
     public function store()
     {
         $user = Auth::user();
-        $defaults = ['text' => '', 'sender_id' => $user->id];
+        $defaults = ['text' => '', 'sender_id' => $user->id, 'contest_id' => $this->contests->firstCurrent()->id];
 
         if ($user->judge || $user->admin) {
             $defaults['is_global'] = true;

--- a/app/Judge/Models/Contest.php
+++ b/app/Judge/Models/Contest.php
@@ -15,6 +15,14 @@ class Contest extends Base
     );
 
     /**
+     * Gets the messages associated with a contest
+     */
+    public function messages()
+    {
+        return $this->hasMany('Judge\Models\Message');
+    }
+
+    /**
      * Gets the problems associated with a contest
      */
     public function problems()

--- a/app/Judge/Models/Message.php
+++ b/app/Judge/Models/Message.php
@@ -19,26 +19,41 @@ class Message extends Base
         return $this->belongsTo('Judge\Models\Contest');
     }
 
+    /**
+     * Gets the problem associated with this message
+     */
     public function problem()
     {
         return $this->belongsTo('Judge\Models\Problem');
     }
 
+    /**
+     * Gets the sender of this message
+     */
     public function sender()
     {
         return $this->belongsTo('Judge\Models\User', 'sender_id');
     }
 
+    /**
+     * Gets the responder to this message
+     */
     public function responder()
     {
         return $this->belongsTo('Judge\Models\User', 'responder_id');
     }
 
+    /**
+     * Gets the response to this message
+     */
     public function getResponseTextAttribute()
     {
         return nl2br($this->attributes['response_text']);
     }
 
+    /**
+     * Gets the text of this message
+     */
     public function getTextAttribute()
     {
         return nl2br($this->attributes['text']);

--- a/app/Judge/Models/Message.php
+++ b/app/Judge/Models/Message.php
@@ -5,6 +5,7 @@ use Judge\Models\Base;
 class Message extends Base
 {
     public static $rules = array(
+        'contest_id' => 'required',
         'sender_id' => 'required',
         'text' => 'required'
     );

--- a/app/Judge/Models/Message.php
+++ b/app/Judge/Models/Message.php
@@ -11,6 +11,14 @@ class Message extends Base
 
     protected $guarded = array('id', 'created_at', 'updated_at');
 
+    /**
+     * Gets the contest associated with this message
+     */
+    public function contest()
+    {
+        return $this->belongsTo('Judge\Models\Contest');
+    }
+
     public function problem()
     {
         return $this->belongsTo('Judge\Models\Problem');

--- a/app/Judge/Repositories/MessageRepository.php
+++ b/app/Judge/Repositories/MessageRepository.php
@@ -1,6 +1,7 @@
 <?php namespace Judge\Repositories;
 
 use Judge\Repositories\ContestRepository;
+use Judge\Models\Contest;
 use Judge\Models\User;
 use Judge\Models\Message;
 
@@ -24,6 +25,7 @@ class MessageRepository
         $contest = $this->resolveContest($contest);
 
         return Message::whereIsGlobal(true)
+            ->whereContestId($contest->id)
             ->orderBy('created_at', 'DESC')
             ->get();
     }
@@ -34,6 +36,7 @@ class MessageRepository
 
         return Message::whereIsGlobal(false)
             ->whereResponderId(null)
+            ->whereContestId($contest->id)
             ->orderBy('created_at', 'ASC')
             ->get();
     }

--- a/app/Judge/Repositories/MessageRepository.php
+++ b/app/Judge/Repositories/MessageRepository.php
@@ -14,11 +14,17 @@ class MessageRepository
 
     protected function resolveContest(Contest $contest = null)
     {
-        if ($contest) {
-            return $contest;
+        // No contest? try to find one
+        if (!$contest) {
+            $contest = $this->contests->firstCurrent();
         }
 
-        return $this->contests->firstCurrent();
+        // Still no contest, just use an empty one, so we can pull an empty id
+        if (!$contest) {
+            $contest = new Contest();
+        }
+
+        return $contest;
     }
 
     public function allGlobal(Contest $contest = null)

--- a/app/Judge/Repositories/MessageRepository.php
+++ b/app/Judge/Repositories/MessageRepository.php
@@ -1,19 +1,37 @@
 <?php namespace Judge\Repositories;
 
+use Judge\Repositories\ContestRepository;
 use Judge\Models\User;
 use Judge\Models\Message;
 
 class MessageRepository
 {
-    public function allGlobal()
+    public function __construct(ContestRepository $contests)
     {
+        $this->contests = $contests;
+    }
+
+    protected function resolveContest(Contest $contest = null) {
+        if($contest) {
+            return $contest;
+        }
+
+        return $this->contests->firstCurrent();
+    }
+
+    public function allGlobal(Contest $contest = null)
+    {
+        $contest = $this->resolveContest($contest);
+
         return Message::whereIsGlobal(true)
             ->orderBy('created_at', 'DESC')
             ->get();
     }
 
-    public function unresponded()
+    public function unresponded(Contest $contest = null)
     {
+        $contest = $this->resolveContest($contest);
+
         return Message::whereIsGlobal(false)
             ->whereResponderId(null)
             ->orderBy('created_at', 'ASC')

--- a/app/Judge/Repositories/MessageRepository.php
+++ b/app/Judge/Repositories/MessageRepository.php
@@ -12,8 +12,9 @@ class MessageRepository
         $this->contests = $contests;
     }
 
-    protected function resolveContest(Contest $contest = null) {
-        if($contest) {
+    protected function resolveContest(Contest $contest = null)
+    {
+        if ($contest) {
             return $contest;
         }
 

--- a/app/Judge/Repositories/MessageRepository.php
+++ b/app/Judge/Repositories/MessageRepository.php
@@ -16,7 +16,7 @@ class MessageRepository
     {
         return Message::whereIsGlobal(false)
             ->whereResponderId(null)
-            ->orderBy('created_at', 'DESC')
+            ->orderBy('created_at', 'ASC')
             ->get();
     }
 }

--- a/app/database/migrations/2015_09_05_185131_add_contest_id_to_messages_table.php
+++ b/app/database/migrations/2015_09_05_185131_add_contest_id_to_messages_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddContestIdToMessagesTable extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+        Schema::table('messages', function (Blueprint $table) {
+
+        	// Foreign key for contests & messages
+        	$table->integer('contest_id')
+        	    ->unsigned()
+        	    ->nullable();
+
+        	$table->foreign('contest_id')
+        		->references('id')
+        		->on('contests')
+        		->onDelete('cascade');
+        });
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+        Schema::table('messages', function (Blueprint $table) {
+
+        	$table->dropForeign('messages_contest_id_foreign');
+        });
+	}
+}

--- a/app/tests/factories/factories.php
+++ b/app/tests/factories/factories.php
@@ -7,6 +7,7 @@ $factory('Judge\Models\Contest', 'contest', [
 ]);
 
 $factory('Judge\Models\Message', 'message', [
+    'contest_id' => 'factory:contest',
     'problem_id' => 'factory:problem',
     'text' => $faker->paragraph,
     'sender_id' => 'factory:team',

--- a/app/tests/integration/DbMessageControllerTest.php
+++ b/app/tests/integration/DbMessageControllerTest.php
@@ -43,11 +43,13 @@ class DbMessageControllerTest extends DbTestCase
 
     public function testStoreForTeam()
     {
+        // create the contest
+        Factory::create('contest');
+
         $team = Factory::create('team');
         Auth::shouldReceive('user')->zeroOrMoreTimes()->andReturn($team);
         
         $this->action('POST', 'Judge\Controllers\MessageController@store', [
-            'contest_id' => Factory::create('contest')->id,
             'text' => 'TEXT'
         ]);
 
@@ -59,11 +61,13 @@ class DbMessageControllerTest extends DbTestCase
 
     public function testStoreForJudge()
     {
+        // create the contest
+        Factory::create('contest');
+
         $judge = Factory::create('judge');
         Auth::shouldReceive('user')->zeroOrMoreTimes()->andReturn($judge);
 
         $this->action('POST', 'Judge\Controllers\MessageController@store', [
-            'contest_id' => Factory::create('contest')->id,
             'text' => 'TEXT'
         ]);
 

--- a/app/tests/integration/DbMessageControllerTest.php
+++ b/app/tests/integration/DbMessageControllerTest.php
@@ -47,6 +47,7 @@ class DbMessageControllerTest extends DbTestCase
         Auth::shouldReceive('user')->zeroOrMoreTimes()->andReturn($team);
         
         $this->action('POST', 'Judge\Controllers\MessageController@store', [
+            'contest_id' => Factory::create('contest')->id,
             'text' => 'TEXT'
         ]);
 
@@ -62,6 +63,7 @@ class DbMessageControllerTest extends DbTestCase
         Auth::shouldReceive('user')->zeroOrMoreTimes()->andReturn($judge);
 
         $this->action('POST', 'Judge\Controllers\MessageController@store', [
+            'contest_id' => Factory::create('contest')->id,
             'text' => 'TEXT'
         ]);
 

--- a/app/tests/integration/DbMessageControllerTest.php
+++ b/app/tests/integration/DbMessageControllerTest.php
@@ -11,10 +11,13 @@ class DbMessageControllerTest extends DbTestCase
         $judge = Factory::create('judge');
         Auth::shouldReceive('user')->zeroOrMoreTimes()->andReturn($judge);
 
-        Factory::create('problem');
+        $contest = Factory::create('contest');
+
+        Factory::create('problem', ['contest_id' => $contest->id]);
         Factory::create('message', [
             'is_global' => false,
-            'responder_id' => null
+            'responder_id' => null,
+            'contest_id' => $contest->id
         ]);
 
         $view = App::make('Judge\Controllers\MessageController')->index();
@@ -24,15 +27,19 @@ class DbMessageControllerTest extends DbTestCase
 
     public function testIndexForTeam()
     {
+        $contest = Factory::create('contest');
+
         $team = Factory::create('team');
         Auth::shouldReceive('user')->zeroOrMoreTimes()->andReturn($team);
 
-        Factory::create('problem');
+        Factory::create('problem', ['contest_id' => $contest->id]);
         Factory::create('message', [
-            'sender_id' => $team->id
+            'sender_id' => $team->id,
+            'contest_id' => $contest->id
         ]);
         Factory::create('message', [
-            'is_global' => true
+            'is_global' => true,
+            'contest_id' => $contest->id
         ]);
 
         $view = App::make('Judge\Controllers\MessageController')->index();

--- a/app/tests/integration/DbMessageRepositoryTest.php
+++ b/app/tests/integration/DbMessageRepositoryTest.php
@@ -37,6 +37,17 @@ class DbMessageRepositoryTest extends DbTestCase
         $this->assertEquals($message_1, $results[1]);
     }
 
+    public function testAllGlobalForDifferentContest()
+    {
+        $message_1 = Factory::create('message', ['is_global' => true]);
+
+        $otherContest = Factory::create('contest');
+
+        $results = $this->repo->allGlobal($otherContest);
+
+        $this->assertCount(0, $results);
+    }
+
     public function testUnrespondedWithNoMatches()
     {
         // the message by default has a responder
@@ -61,5 +72,16 @@ class DbMessageRepositoryTest extends DbTestCase
         // Results should appear in reverse chronological order
         $this->assertEquals($message_1->id, $results[0]->id);
         $this->assertEquals($message_2->id, $results[1]->id);
+    }
+
+    public function testUnrespondedForOtherContest()
+    {
+        $message_1 = Factory::create('message', ['is_global' => false, 'responder_id' => null]);
+
+        $otherContest = Factory::create('contest');
+
+        $results = $this->repo->unresponded($otherContest);
+
+        $this->assertCount(0, $results);
     }
 }

--- a/app/tests/integration/DbMessageRepositoryTest.php
+++ b/app/tests/integration/DbMessageRepositoryTest.php
@@ -59,7 +59,7 @@ class DbMessageRepositoryTest extends DbTestCase
         $results = $this->repo->unresponded();
 
         // Results should appear in reverse chronological order
-        $this->assertEquals($message_2->id, $results[0]->id);
-        $this->assertEquals($message_1->id, $results[1]->id);
+        $this->assertEquals($message_1->id, $results[0]->id);
+        $this->assertEquals($message_2->id, $results[1]->id);
     }
 }

--- a/app/tests/integration/DbMessageRepositoryTest.php
+++ b/app/tests/integration/DbMessageRepositoryTest.php
@@ -49,6 +49,13 @@ class DbMessageRepositoryTest extends DbTestCase
         $this->assertCount(0, $results);
     }
 
+    public function testAllGlobalWithMissingContest()
+    {
+        $results = $this->repo->allGlobal();
+
+        $this->assertCount(0, $results);
+    }
+
     public function testUnrespondedWithNoMatches()
     {
         // the message by default has a responder

--- a/app/tests/integration/DbMessageRepositoryTest.php
+++ b/app/tests/integration/DbMessageRepositoryTest.php
@@ -27,14 +27,15 @@ class DbMessageRepositoryTest extends DbTestCase
 
     public function testAllGlobalForCorrectSorting()
     {
-        $message_1 = Factory::create('message', ['is_global' => true, 'created_at' => Carbon::now()->subDay()]);
-        $message_2 = Factory::create('message', ['is_global' => true, 'created_at' => Carbon::now()]);
+        $contest = Factory::create('contest');
+        $message_1 = Factory::create('message', ['is_global' => true, 'created_at' => Carbon::now()->subDay(), 'contest_id' => $contest->id]);
+        $message_2 = Factory::create('message', ['is_global' => true, 'created_at' => Carbon::now(), 'contest_id' => $contest->id]);
 
         $results = $this->repo->allGlobal();
 
         // Results should appear in reverse chronological order
-        $this->assertEquals($message_2, $results[0]);
-        $this->assertEquals($message_1, $results[1]);
+        $this->assertEquals($message_2->id, $results[0]->id);
+        $this->assertEquals($message_1->id, $results[1]->id);
     }
 
     public function testAllGlobalForDifferentContest()
@@ -64,8 +65,9 @@ class DbMessageRepositoryTest extends DbTestCase
 
     public function testUnrespondedForCorrectSorting()
     {
-        $message_1 = Factory::create('message', ['is_global' => false, 'responder_id' => null, 'created_at' => Carbon::now()->subDay()]);
-        $message_2 = Factory::create('message', ['is_global' => false, 'responder_id' => null, 'created_at' => Carbon::now()]);
+        $contest = Factory::create('contest');
+        $message_1 = Factory::create('message', ['is_global' => false, 'responder_id' => null, 'created_at' => Carbon::now()->subDay(), 'contest_id' => $contest->id]);
+        $message_2 = Factory::create('message', ['is_global' => false, 'responder_id' => null, 'created_at' => Carbon::now(), 'contest_id' => $contest->id]);
 
         $results = $this->repo->unresponded();
 

--- a/app/tests/unit/ContestTest.php
+++ b/app/tests/unit/ContestTest.php
@@ -10,6 +10,11 @@ class ContestTest extends TestCase
 
         $this->contest = new Contest();
     }
+
+    public function testMessages()
+    {
+        $this->assertInstanceOf('Illuminate\Database\Eloquent\Relations\HasMany', $this->contest->messages());
+    }
     
     public function testProblems()
     {

--- a/app/tests/unit/MessageTest.php
+++ b/app/tests/unit/MessageTest.php
@@ -17,6 +17,11 @@ class MessageTest extends TestCase
         Mockery::close();
     }
 
+    public function testContestRelationship()
+    {
+        $this->assertInstanceOf('Illuminate\Database\Eloquent\Relations\BelongsTo', $this->message->contest());
+    }
+
     public function testProblemRelationship()
     {
         $this->assertInstanceOf('Illuminate\Database\Eloquent\Relations\BelongsTo', $this->message->problem());


### PR DESCRIPTION
Fixes #86.

 * Add new column to messages table: contest_id
 * Add proper eloquent relationships to Contest and Message
 * Add/edit unit tests to account for these changes