### PR TITLE
Add tests that cover the changes from #85

### DIFF
--- a/app/tests/integration/DbMessageRepositoryTest.php
+++ b/app/tests/integration/DbMessageRepositoryTest.php
@@ -59,7 +59,7 @@ class DbMessageRepositoryTest extends DbTestCase
         $results = $this->repo->unresponded();
 
         // Results should appear in reverse chronological order
-        $this->assertEquals($message_2, $results[0]);
-        $this->assertEquals($message_1, $results[1]);
+        $this->assertEquals($message_2->id, $results[0]->id);
+        $this->assertEquals($message_1->id, $results[1]->id);
     }
 }

--- a/app/tests/integration/DbMessageRepositoryTest.php
+++ b/app/tests/integration/DbMessageRepositoryTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Carbon\Carbon;
 use Illuminate\Support\Facades\App;
 use Laracasts\TestDummy\Factory;
 
@@ -24,6 +25,18 @@ class DbMessageRepositoryTest extends DbTestCase
         $this->assertCount(1, $this->repo->allGlobal());
     }
 
+    public function testAllGlobalForCorrectSorting()
+    {
+        $message_1 = Factory::create('message', ['is_global' => true, 'created_at' => Carbon::now()->subDay()]);
+        $message_2 = Factory::create('message', ['is_global' => true, 'created_at' => Carbon::now()]);
+
+        $results = $this->repo->allGlobal();
+
+        // Results should appear in reverse chronological order
+        $this->assertEquals($message_2, $results[0]);
+        $this->assertEquals($message_1, $results[1]);
+    }
+
     public function testUnrespondedWithNoMatches()
     {
         // the message by default has a responder
@@ -36,5 +49,17 @@ class DbMessageRepositoryTest extends DbTestCase
         // Create a message with no responder
         Factory::create('message', ['is_global' => false, 'responder_id' => null]);
         $this->assertCount(1, $this->repo->unresponded());
+    }
+
+    public function testUnrespondedForCorrectSorting()
+    {
+        $message_1 = Factory::create('message', ['is_global' => false, 'responder_id' => null, 'created_at' => Carbon::now()->subDay()]);
+        $message_2 = Factory::create('message', ['is_global' => false, 'responder_id' => null, 'created_at' => Carbon::now()]);
+
+        $results = $this->repo->unresponded();
+
+        // Results should appear in reverse chronological order
+        $this->assertEquals($message_2, $results[0]);
+        $this->assertEquals($message_1, $results[1]);
     }
 }


### PR DESCRIPTION
I forgot to add tests for #85, so here they are.

However, one of the tests is failing, and it's weird!

The `testUnrespondedForCorrectSorting` method comes back with:

```bash
Failed asserting that two objects are equal.
--- Expected
+++ Actual
@@ @@
     'attributes' => Array (
-        'problem_id' => 2
+        'problem_id' => '2'
         'text' => 'Assumenda eius expedita minim...ullam.'
-        'sender_id' => 3
+        'sender_id' => '3'
         'response_text' => 'Delectus neque natus quibusda...em ut.'
         'responder_id' => null
-        'is_global' => false
+        'is_global' => '0'
         'created_at' => '2015-09-05 20:12:32'
         'updated_at' => '2015-09-05 20:12:32'
-        'id' => 2
+        'id' => '2'
     )
     'original' => Array (
-        'problem_id' => 2
+        'problem_id' => '2'
         'text' => 'Assumenda eius expedita minim...ullam.'
-        'sender_id' => 3
+        'sender_id' => '3'
         'response_text' => 'Delectus neque natus quibusda...em ut.'
         'responder_id' => null
-        'is_global' => false
+        'is_global' => '0'
         'created_at' => '2015-09-05 20:12:32'
         'updated_at' => '2015-09-05 20:12:32'
-        'id' => 2
+        'id' => '2'
     )
```

Do you know what this is about? I'm confused! I'm using SQLite for the tests.